### PR TITLE
Added files_name_map option to set custom files names inside the zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ class UsersController < ApplicationController
   def show
     respond_to do |format|
       format.html { render }
-      format.zip { send_zip(@user.pictures, files_name_map: @user.pictures.map { |p| "custom_#{p..filename.to_s}" } ) }
+      format.zip { send_zip(@user.pictures, files_name_map: @user.pictures.map { |p| "custom_#{p.filename.to_s}" } ) }
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -80,6 +80,48 @@ Will produce a `.zip` archive like this:
     └── c.gif
 ~~~
 
+## Options
+
+### Set custom zip filename
+
+~~~ruby
+# app/controllers/users_controller.rb
+class UsersController < ApplicationController
+  include ActiveStorage::SendZip
+
+  # ...
+
+  # GET /users/1
+  # GET /users/1.zip
+  def show
+    respond_to do |format|
+      format.html { render }
+      format.zip { send_zip(@user.pictures, filename: 'my_zip_name.zip') }
+    end
+  end
+end
+~~~
+
+### Set custom file names
+
+~~~ruby
+# app/controllers/users_controller.rb
+class UsersController < ApplicationController
+  include ActiveStorage::SendZip
+
+  # ...
+
+  # GET /users/1
+  # GET /users/1.zip
+  def show
+    respond_to do |format|
+      format.html { render }
+      format.zip { send_zip(@user.pictures, files_name_map: @user.pictures.map { |p| "custom_#{p..filename.to_s}" } ) }
+    end
+  end
+end
+~~~
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/active_storage/send_zip.rb
+++ b/lib/active_storage/send_zip.rb
@@ -14,9 +14,10 @@ module ActiveStorage
     #
     # @param active_storages [ActiveStorage::Attached::Many] files to save
     # @param filename [ActiveStorage::Attached::Many] files to save
-    def send_zip(active_storages, filename: 'my.zip', file_name_map: nil)
+    # @params files_name_map [Array|Hash] an object with the same structure of active_storages with the name for each file
+    def send_zip(active_storages, filename: 'my.zip', files_name_map: nil)
       require 'zip'
-      files = SendZipHelper.save_files_on_server(active_storages, file_name_map)
+      files = SendZipHelper.save_files_on_server(active_storages, files_name_map)
       zip_data = SendZipHelper.create_temporary_zip_file files
 
       send_data(zip_data, type: 'application/zip', filename: filename)

--- a/lib/active_storage/send_zip.rb
+++ b/lib/active_storage/send_zip.rb
@@ -14,10 +14,10 @@ module ActiveStorage
     #
     # @param active_storages [ActiveStorage::Attached::Many] files to save
     # @param filename [ActiveStorage::Attached::Many] files to save
-    # @params files_name_map [Array|Hash] an object with the same structure of active_storages with the name for each file
-    def send_zip(active_storages, filename: 'my.zip', files_name_map: nil)
+    # @params filenames_map [Hash|Array|nil] an object with the same structure of active_storages with the name for each file
+    def send_zip(active_storages, filename: 'my.zip', filenames_map: nil)
       require 'zip'
-      files = SendZipHelper.save_files_on_server(active_storages, files_name_map)
+      files = SendZipHelper.save_files_on_server(active_storages, filenames_map)
       zip_data = SendZipHelper.create_temporary_zip_file files
 
       send_data(zip_data, type: 'application/zip', filename: filename)

--- a/lib/active_storage/send_zip.rb
+++ b/lib/active_storage/send_zip.rb
@@ -14,9 +14,9 @@ module ActiveStorage
     #
     # @param active_storages [ActiveStorage::Attached::Many] files to save
     # @param filename [ActiveStorage::Attached::Many] files to save
-    def send_zip(active_storages, filename: 'my.zip')
+    def send_zip(active_storages, filename: 'my.zip', file_name_map: nil)
       require 'zip'
-      files = SendZipHelper.save_files_on_server active_storages
+      files = SendZipHelper.save_files_on_server(active_storages, file_name_map)
       zip_data = SendZipHelper.create_temporary_zip_file files
 
       send_data(zip_data, type: 'application/zip', filename: filename)

--- a/lib/active_storage/send_zip_helper.rb
+++ b/lib/active_storage/send_zip_helper.rb
@@ -48,7 +48,8 @@ module ActiveStorage
     # @param folder [String] where to store the file
     # @return [String] the filepath of file created
     def self.save_file_on_server(file, folder, file_name, subfolder: nil)
-      filename = file_name ? file_name : file.filename.to_s
+      ext = file.filename.to_s.split('.').last
+      filename = file_name ? "#{file_name}.#{ext}" : file.filename.to_s
 
       folder = File.join(folder, subfolder) unless subfolder.nil?
       Dir.mkdir(folder) unless Dir.exist?(folder)


### PR DESCRIPTION
Added a new options files_name_map. It should be an object with the same structure of active_storages (hash or array). It should be used to set a custom name on pictures.

Example of usage: 

```ruby
def download_images
      pictures = Picture.actives.where(workspace_uuid: @session.workspace_uuid)
      send_zip(
        pictures.map(&:original_image),
        files_name_map: pictures.map(&:uuid),
        filename: "#{@session.workspace.name.parameterize}_#{Date.today.to_s.parameterize}.zip"
      )
end
```